### PR TITLE
feat: add secure examples (pinned image, non-root, no priv escalation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ No local installation of Trivy is needed.
 
 ## Roadmap
 
+## Examples
+- `examples/Dockerfile.good` and `examples/pod-secure.yaml` demonstrate a passing configuration.
+- For a failing demo, see the "Purposefully Failing PR – Guardrails Demo" branch/PR.
+
 - [x] Repo scaffolded
 - [x] Pre-commit (Gitleaks)
 - [x] CI: Trivy vuln + SBOM

--- a/examples/Dockerfile.good
+++ b/examples/Dockerfile.good
@@ -1,0 +1,6 @@
+# Secure example: pinned, small, non-root
+FROM nginx:1.27.2-alpine
+# Create an unprivileged user and use it
+RUN adduser -D -u 101 appuser
+USER 101:101
+# Default nginx starts as this user in alpine variant

--- a/examples/pod-secure.yaml
+++ b/examples/pod-secure.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: nginx:1.27.2-alpine
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsUser: 101


### PR DESCRIPTION
## What
-  `Dockerfile.good` (added)
-  `pod-secure.yaml` (added)

## Why
-  show the green path that passes existing guardrails

## How tested
- [ x] Local: `make scan`  shows no HIGH/CRITICAL vulnerabilities
- [ x] CI: Security workflow green on this branch
- [ ] Screenshots / logs (optional):
  - 

## Risk & rollout
- [ ] Backward compatible
- [ x] Docs updated (README / docs/)
- [ x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ x] fix
- [ ] docs
- [ ] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run