### PR TITLE
Test/secure examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ No local installation of Trivy is needed.
 
 ## Roadmap
 
+## Examples
+- `examples/Dockerfile.good` and `examples/pod-secure.yaml` demonstrate a passing configuration.
+- For a failing demo, see the "Purposefully Failing PR – Guardrails Demo" branch/PR.
+
 - [x] Repo scaffolded
 - [x] Pre-commit (Gitleaks)
 - [x] CI: Trivy vuln + SBOM

--- a/examples/Dockerfile.good
+++ b/examples/Dockerfile.good
@@ -1,6 +1,12 @@
-# Secure example: pinned, small, non-root
+# Secure example: pinned, small, non-root 
+# Smaller base images = smaller attack surface
 FROM nginx:1.27.2-alpine
-# Create an unprivileged user and use it
-RUN adduser -D -u 101 appuser
-USER 101:101
+# Create an unprivileged user and use it. 
+RUN adduser -D -u 10001 appuser
+USER 10001:10001
 # Default nginx starts as this user in alpine variant
+
+# Run on an unpriveleged port (>1024) so we don't need NET_BIND_SERVICE
+EXPOSE 8080
+
+# We can improve this Dockerfile quite a bit, but I want to keep it simple for now

--- a/examples/Dockerfile.good
+++ b/examples/Dockerfile.good
@@ -1,0 +1,6 @@
+# Secure example: pinned, small, non-root
+FROM nginx:1.27.2-alpine
+# Create an unprivileged user and use it
+RUN adduser -D -u 101 appuser
+USER 101:101
+# Default nginx starts as this user in alpine variant

--- a/examples/pod-secure.yaml
+++ b/examples/pod-secure.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: app
+      image: nginx:1.27.2-alpine
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsUser: 101

--- a/examples/pod-secure.yaml
+++ b/examples/pod-secure.yaml
@@ -1,16 +1,38 @@
+# This is not meant to be a real manifest. Just used for testing purposes
 apiVersion: v1
 kind: Pod
 metadata:
   name: secure-pod
 spec:
   securityContext:
-    runAsNonRoot: true
+    runAsNonRoot: true # Explicitly require non-root execution
   containers:
     - name: app
       image: nginx:1.27.2-alpine
+      ports:
+        - containerPort: 8080
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
-          drop: ["ALL"]
-        readOnlyRootFilesystem: true
-        runAsUser: 101
+          drop: ["ALL"] # Drop ALL Capabilities (best default for now)
+        readOnlyRootFilesystem: true # Stop attackers from writing to container's FS
+        runAsUser: 10001
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 10
+        periodSeconds: 20      


### PR DESCRIPTION
## What
- Added `Insecure Examples` section to README with permanent links to intentionally insecure files (`Dockerfile.bad`, `pod-insecure.yaml`, `bad_secrets.txt`) via `demo-bad-examples-v1` tag.
- Added improved configuration to be more realistic for Dockerfile and Pod manifest
- Added `Secure Examples` section to README linking hardened Dockerfile and Pod manifest.
- Added `Security Best Practices` table outlining 8 core practices with rationale and external references.
- Added UID 10001 rationale in README for running containers as a non-root user.

## Why
- Improves discoverability of both secure and insecure examples.
- Makes the README a self-contained security learning resource.
- Ensures permanent references to insecure examples without merging them to `main`.
- Documents real-world, battle-tested Kubernetes/Docker hardening aligned with CNCF/NSA/NIST guidance.

## How tested
- [x] Local: `pre-commit` passes
- [x] CI: Security workflow green on this branch
- [x] Screenshots / logs (optional):
  - Previewed README rendering locally.
  - Verified insecure example links resolve to tagged commit.
  - CI green for secure examples.

## Risk & rollout
- [x] Backward compatible
- [x] Docs updated (README / docs/)
- [x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [x] docs
- [ ] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run
