### PR TITLE
Ci/scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date (e.g., trivy-action, upload-artifact, checkout)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Australia/Melbourne"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    # Group minor+patch updates into one PR to reduce noise
+    groups:
+      actions-minor:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Keep Docker base images in examples/ current (e.g., nginx:1.27.x-alpine)
+  - package-ecosystem: "docker"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "Australia/Melbourne"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "container"]
+    groups:
+      docker-minor:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+name: openssf-scorecard
+
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    # Weekly on Fridays at 01:15 UTC (Saturday morning AEST)
+    - cron: "15 1 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write   # upload SARIF to code scanning
+  id-token: write          # required when publish_results: true
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (no persist creds)
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.3.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true    # enables public badge via the Scorecard API
+
+      - name: Upload results to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+ 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Secure by Default Starter
 [![Security](https://github.com/cloudnativeciso/secure-by-default-starter/actions/workflows/security.yml/badge.svg)](https://github.com/cloudnativeciso/secure-by-default-starter/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen.svg)](#)
+
 
 A minimal, security-first kit that drops into any repo to add developer-friendly guardrails:  
 pre-commit secret scanning, CI dependency checks, and an SPDX SBOM.
@@ -20,6 +22,9 @@ pre-commit secret scanning, CI dependency checks, and an SPDX SBOM.
   - Downloadable as a workflow artifact.
 - **Local parity via Makefile**
   - Run the same CI scans locally in Docker, no extra installs needed.
+- **Automated dependency updates** via Dependabot
+  - Weekly PRs for GitHub Actions and Docker base images, labeled `dependencies`.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Security](https://github.com/cloudnativeciso/secure-by-default-starter/actions/workflows/security.yml/badge.svg)](https://github.com/cloudnativeciso/secure-by-default-starter/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen.svg)](#)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cloudnativeciso/secure-by-default-starter/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cloudnativeciso/secure-by-default-starter)
 
 
 A minimal, security-first kit that drops into any repo to add developer-friendly guardrails:  
@@ -24,6 +25,8 @@ pre-commit secret scanning, CI dependency checks, and an SPDX SBOM.
   - Run the same CI scans locally in Docker, no extra installs needed.
 - **Automated dependency updates** via Dependabot
   - Weekly PRs for GitHub Actions and Docker base images, labeled `dependencies`.
+- **OpenSSF Scorecard** for Trust & Compliance signals
+  - Checks basic hygiene (CI, Code-Review, Branch Protection, etc)
 
 
 ---


### PR DESCRIPTION
## What
- Added scorecard.yml (for OpenSSF)
- Updated README with Scorecard Badge

## Why
- Showcase CNCISO secure development practices for trust

## How tested
- [x] Local: `pre-commit` passes
- [x] CI: Security workflow green on this branch
- [ ] Screenshots / logs (optional):
  - 

## Risk & rollout
- [x] Backward compatible
- [x] Docs updated (README / docs/)
- [x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run