### PR TITLE
Ci/precommit hygiene

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "CNCISO gitleaks policy (strict by default)"
+
+[allowlist]
+description = "Allow ONLY clearly marked test lines (sentinel) under examples/"
+paths = [
+  '''^examples/'''
+]
+regexes = [
+  # Allow lines that include this sentinel (put it on the SAME line as your fake token)
+  '''CNCISO_FAKE_SECRET'''
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
 
   # 2) Language-agnostic hygiene hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,18 @@
 repos:
-- repo: https://github.com/gitleaks/gitleaks
-  # Pinned tag; we'll update later with 'pre-commit auto-update'
-  rev: v8.28.0
-  hooks:
-  - id: gitleaks
-    # Optional: speed up by skipping large dirs (edit as needed)
-    exclude: "(^dist/|^build/|^reports/)" 
+  - repo: https://github.com/gitleaks/gitleaks
+    # Pinned tag; we'll update later with 'pre-commit auto-update'
+    rev: v8.28.0
+    hooks:
+    - id: gitleaks
+      args: ["--staged", "--redact"]
+      # Optional: speed up by skipping large dirs (edit as needed)
+      exclude: "(^dist/|^build/|^reports/)"
+
+  # 2) Language-agnostic hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: detect-private-key


### PR DESCRIPTION
## What
- Added extra pre-commit stage to check for whitespace
- added .gitleaks.toml (to allow for exceptions later for bad examples)

## Why
- 

## How tested
- [x] Local: `pre-commit` passes
- [x] CI: Security workflow green on this branch
- [x] Screenshots / logs (optional):
  - 

## Risk & rollout
- [x] Backward compatible
- [x] Docs updated (README / docs/)
- [x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run