### PR TITLE
ci: Makefile parity with CI (pinned Trivy, SPDX SBOM, cache)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,50 @@
-SHELL := /bin/zsh
+# Makefile: local parity with CI
+# ------------------------------------------------------------
+# Usage:
+#   make hooks      # install/refresh pre-commit hooks
+#   make scan       # Trivy vuln + IaC scan (fails on HIGH/CRITICAL)
+#   make sbom       # Generate SPDX JSON to sbom.spdx.json
+#   make ci         # run scan + sbom (what CI does, locally)
+#
+# Bump this to track the CI version in one place.
+TRIVY_VERSION ?= 0.65.0
+TRIVY_IMAGE   ?= aquasec/trivy:$(TRIVY_VERSION)
 
-.PHONY: scan sbom
+SRC_DIR       := /src
+CACHE_DIR     := $(HOME)/.cache/trivy
+DOCKER_RUN    := docker run --rm \
+                   -v $(PWD):$(SRC_DIR) \
+                   -v $(CACHE_DIR):/root/.cache/ \
+                   $(TRIVY_IMAGE)
 
-# Runs the same Trivy vuln+config scan as the Github Action
+.PHONY: hooks scan sbom ci help
+
+help:
+	@echo "Targets:"
+	@echo "  make hooks   - install/update pre-commit hooks (gitleaks + hygiene)"
+	@echo "  make scan    - run Trivy vuln + IaC scan (HIGH/CRITICAL gate)"
+	@echo "  make sbom    - generate SPDX SBOM (sbom.spdx.json)"
+	@echo "  make ci      - run scan + sbom (local parity with CI)"
+
+hooks:
+	pre-commit install
+	pre-commit autoupdate
+
+# Mirrors CI: vuln + config scanners, ignore unfixed, HIGH/CRITICAL gate
 scan:
-	@echo "==> Trivy filesystem scan (vuln + config)"
-	docker run --rm -v $$PWD:/repo aquasec/trivy:latest fs --scanners vuln,config /repo
+	$(DOCKER_RUN) fs \
+	  --scanners vuln,config \
+	  --ignore-unfixed \
+	  --severity HIGH,CRITICAL \
+	  --exit-code 1 \
+	  $(SRC_DIR)
 
-# Generates an SPDX SBOM locally (same format as CI artifact)
+# Mirrors CI: SPDX JSON SBOM artifact
 sbom:
-	@echo "==> Trivy SBOM (SPDX JSON)"
-	docker run --rm -v $$PWD:/repo aquasec/trivy:latest fs --format spdx-json /repo > sbom.spdx.json && \
-	echo "SBOM written to ./sbom.spdx.json"
+	$(DOCKER_RUN) fs \
+	  --format spdx-json \
+	  --output sbom.spdx.json \
+	  $(SRC_DIR)
+	@echo "SBOM written to sbom.spdx.json"
+
+ci: scan sbom


### PR DESCRIPTION
## What
- Updated Makefile to be on par with current CI

## Why
- For local testing

## How tested
- [x] Local: `pre-commit` passes
- [x] CI: Security workflow green on this branch
- [] Screenshots / logs (optional):
  - 

## Risk & rollout
- [x] Backward compatible
- [x] Docs updated (README / docs/)
- [x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run