### PR TITLE
docs: add Trust & Transparency badge linking to trust page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen.svg)](#)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cloudnativeciso/secure-by-default-starter/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cloudnativeciso/secure-by-default-starter)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Trust & Transparency](https://img.shields.io/badge/Trust%20%26%20Transparency-view-blue)](./docs/trust-page.md)
 
 ---
 
@@ -162,6 +163,19 @@ make sbom   # SBOM generation (SPDX JSON)
 | Read-only root filesystem  | Pod `securityContext`     | Prevents tampering/persistence.                               |
 | Resource requests/limits   | Pod `resources`           | Prevents noisy-neighbor/DoS via resource exhaustion.          |
 | Pinned base image          | Dockerfile                | Reduces CVE drift from `:latest`.                             |
+
+---
+
+## Trust & Transparency
+
+For executive stakeholders and security reviewers, we maintain a concise
+[**Security & Trust Overview**](./docs/trust-page.md) page with:
+
+- Latest CI security scan status
+- Where to download the most recent SBOM
+- Guardrails currently active in the repo
+- Policy exception workflow
+- Security contact information
 
 ---
 

--- a/docs/trust-page.md
+++ b/docs/trust-page.md
@@ -1,0 +1,20 @@
+# Security & Trust Overview
+
+**Last CI security scan:** ![Security Workflow](https://github.com/cloudnativeciso/secure-by-default-starter/actions/workflows/security.yml/badge.svg)
+**Latest SBOM artifact:** Available via **GitHub Actions → latest run → Artifacts → `sbom-spdx`**
+**Guardrails in place:**
+- Secrets scanning (pre-commit Gitleaks)
+- CI vulnerability & IaC scanning (Trivy, fails on HIGH/CRITICAL)
+- SPDX SBOM generated for every run
+- OpenSSF Scorecard for secure SDLC hygiene
+
+**Policy exception process:**
+Tracked via GitHub Issues → **Security Exception Request** form
+(see `.github/ISSUE_TEMPLATE/security-exception.yml`)
+
+**Contact:** [security@cloudnativeciso.com](mailto:security@cloudnativeciso.com)
+
+---
+
+> This page provides a starter “trust” view for stakeholders.
+> All data is current as of the latest CI run.


### PR DESCRIPTION
## What
- Added Trust page

## Why
- For consistency and transparency for users and stakeholders

## How tested
- [x] Local: `pre-commit` passes
- [ ] CI: Security workflow green on this branch
- [ ] Screenshots / logs (optional):
  - 

## Risk & rollout
- [ ] Backward compatible
- [x] Docs updated (README / docs/)
- [ ] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [x] docs
- [ ] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run