### PR TITLE
ci/docs: dynamic trust badge from security run

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,14 @@
 name: security
 
-on: 
+on:
   pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
-    
+
 permissions:
-  contents: read
+  contents: write
   security-events: write    # needed to upload SARIF
 
 concurrency:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      
+
       # === Optional: Install Trivy CLI ===
       # Github's ubuntu-latest runner currently has Trivy pre-installed
       # Uncomment this if using a custom runner or if you need to pin a specific version
@@ -122,6 +122,37 @@ jobs:
           name: security-summary
           path: security-summary.md
 
+      - name: Ensure badges directory exists
+        if: always()
+        run: mkdir -p docs/badges
+
+      - name: Publish dynamic Trust badge JSON
+        if: always()
+        run: |
+          VULN_COUNT=$(jq '[.Results[]? | .Vulnerabilities[]?] | length' trivy.high_critical.json 2>/dev/null || echo 0)
+          MISCONF_COUNT=$(jq '[.Results[]? | .Misconfigurations[]?] | map(select(.Severity=="HIGH" or .Severity=="CRITICAL")) | length' trivy.high_critical.json 2>/dev/null || echo 0)
+
+          STATUS_MSG="passing"
+          COLOR="success"
+          if [ "$VULN_COUNT" -gt 0 ] || [ "$MISCONF_COUNT" -gt 0 ]; then
+            STATUS_MSG="failing"
+            COLOR="critical"
+          fi
+
+          cat > docs/badges/trust-badge.json <<JSON
+          {
+            "schemaVersion": 1,
+            "label": "trust",
+            "message": "${STATUS_MSG}",
+            "color": "${COLOR}"
+          }
+          JSON
+
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add docs/badges/trust-badge.json
+          git commit -m "ci: update trust badge (auto) [skip ci]" || echo "No changes to badge"
+          git push
 
       # --- Explicit Gate: fail only if HIGH/CRITICAL exist ---
       - name: Gate on HIGH/CRITICAL (Trivy CLI)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -148,11 +148,13 @@ jobs:
           }
           JSON
 
-          git config user.name "github-actions"
-          git config user.email "actions@github.com"
-          git add docs/badges/trust-badge.json
-          git commit -m "ci: update trust badge (auto) [skip ci]" || echo "No changes to badge"
-          git push
+      - name: Commit Trust badge (auto)
+        if: always() && github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci: update trust badge (auto) [skip ci]"
+          file_pattern: docs/badges/trust-badge.json
+
 
       # --- Explicit Gate: fail only if HIGH/CRITICAL exist ---
       - name: Gate on HIGH/CRITICAL (Trivy CLI)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-brightgreen.svg)](#)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cloudnativeciso/secure-by-default-starter/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cloudnativeciso/secure-by-default-starter)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Trust & Transparency](https://img.shields.io/badge/Trust%20%26%20Transparency-view-blue)](./docs/trust-page.md)
+[![Trust & Transparency](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/cloudnativeciso/secure-by-default-starter/main/docs/badges/trust-badge.json)](./docs/trust-page.md)
+
 
 ---
 


### PR DESCRIPTION
## What
- Added dynamic indicator for trust badge

## Why
- Instantly view status of security checks within repo

## How tested
- [x] Local: `pre-commit` passes
- [ ] CI: Security workflow green on this branch
- [ ] Screenshots / logs (optional):
  - 

## Risk & rollout
- [x] Backward compatible
- [x] Docs updated (README / docs/)
- [x] No secrets or sensitive data introduced

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [x] chore/ci
- [ ] test

---

### Guardrails checklist (automated)
- Pre-commit: **Gitleaks** blocks secrets locally
- CI: **Trivy** uploads SARIF to Code Scanning
- CI: **SBOM** artifact (spdx) published on each run